### PR TITLE
typo, missing Info.plist

### DIFF
--- a/Appify UI Node Demo.app/Contents/Resources/app/main.js
+++ b/Appify UI Node Demo.app/Contents/Resources/app/main.js
@@ -17,7 +17,7 @@ var webviewServer = require('./lib/http-webview').create(function(request, respo
   response.write('</a>')
   
   response.write('<p>')
-  response.write('<a href="txmt://open?url=file://' + __filename + '/../../Info.plist">')
+  response.write('<a href="txmt://open?url=file://' + __filename + '/../../../Info.plist">')
   response.write("Be sure to change the CFBundleIdentifier")
   response.write('</a>')
   


### PR DESCRIPTION
a directory traversal sign was missing, to reach Info.plist when clicking "Be sure to change the CFBundleIdentifier" in this Demo App
